### PR TITLE
Encodings datamodel

### DIFF
--- a/common/dynamo_defs.go
+++ b/common/dynamo_defs.go
@@ -1,5 +1,97 @@
 package common
 
-import "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"log"
+	"reflect"
+	"strconv"
+)
 
 type RawDynamoRecord map[string]types.AttributeValue
+
+/*
+extractDynamoField is an internal method that grabs the relevant field from Dynamodb, casts it to the right type
+and returns it as an interface.
+
+The return value is `nil` if either the field does not exist or is the wrong type.
+If a value is returned it should always be castable to the type given in the `t` parameter without further checks
+*/
+func extractDynamoField(rec *RawDynamoRecord, fieldName string, t reflect.Kind, nullable bool) interface{} {
+	if dynamoValue, valueExists := (*rec)[fieldName]; valueExists {
+		switch t {
+		case reflect.String:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberS); isRightType {
+				return v.Value
+			} else {
+				log.Printf("WARNING Field %s was not castable to a string", fieldName)
+				return nil
+			}
+		case reflect.Int32:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseInt(v.Value, 10, 32)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to int32: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return int32(intval)
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
+		case reflect.Int64:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseInt(v.Value, 10, 64)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to int64: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return intval
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
+		case reflect.Float32:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseFloat(v.Value, 32)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to float32: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return float32(intval)
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
+		case reflect.Bool:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberBOOL); isRightType {
+				return v.Value
+			} else {
+				log.Printf("WARNING Field %s was not castable to a bool", fieldName)
+				return nil
+			}
+		default:
+			log.Printf("WARNING Field %s has a type of %s which is not handled", fieldName, reflect.TypeOf(dynamoValue))
+			return nil
+		}
+	} else {
+		if nullable {
+			switch t {
+			case reflect.String:
+				return ""
+			case reflect.Int32:
+				return int32(0)
+			case reflect.Int64:
+				return int64(0)
+			case reflect.Float32:
+				return float32(0)
+			case reflect.Bool:
+				return false
+			default:
+				return nil
+			}
+		} else {
+			log.Printf("WARNING Field %s does not exist on the incoming record", fieldName)
+			return nil
+		}
+	}
+}

--- a/common/dynamo_defs.go
+++ b/common/dynamo_defs.go
@@ -1,0 +1,5 @@
+package common
+
+import "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+type RawDynamoRecord map[string]types.AttributeValue

--- a/common/find_content.go
+++ b/common/find_content.go
@@ -8,9 +8,6 @@ import (
 	"strconv"
 )
 
-type ContentResult struct {
-}
-
 /**
 isFilenameValid validates the contents of the filename and returns true if it is ok.
 If not, false is returned

--- a/common/model_contentresult.go
+++ b/common/model_contentresult.go
@@ -1,0 +1,8 @@
+package common
+
+type ContentResult struct {
+	Encoding
+
+	RealMimeName string `json:"real_name"` //optional string containing the MIME type equivalent
+	PosterURL    string `json:"posterurl"` //optional string containing a URL for the poster image if it exists
+}

--- a/common/model_encoding.go
+++ b/common/model_encoding.go
@@ -2,10 +2,8 @@ package common
 
 import (
 	"errors"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"log"
 	"reflect"
-	"strconv"
 	"time"
 )
 
@@ -34,93 +32,6 @@ type Encoding struct {
 }
 
 /*
-extractContentResultField is an internal method that grabs the relevant field from Dynamodb, casts it to the right type
-and returns it as an interface.
-
-The return value is `nil` if either the field does not exist or is the wrong type.
-If a value is returned it should always be castable to the type given in the `t` parameter without further checks
-*/
-func extractContentResultField(rec *RawDynamoRecord, fieldName string, t reflect.Kind, nullable bool) interface{} {
-	if dynamoValue, valueExists := (*rec)[fieldName]; valueExists {
-		switch t {
-		case reflect.String:
-			if v, isRightType := dynamoValue.(*types.AttributeValueMemberS); isRightType {
-				return v.Value
-			} else {
-				log.Printf("WARNING Field %s was not castable to a string", fieldName)
-				return nil
-			}
-		case reflect.Int32:
-			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
-				intval, err := strconv.ParseInt(v.Value, 10, 32)
-				if err != nil {
-					log.Printf("WARNING Field %s value %s could not be converted to int32: %s", fieldName, v.Value, err)
-					return nil
-				}
-				return int32(intval)
-			} else {
-				log.Printf("WARNING Field %s was not castable to a number", fieldName)
-				return nil
-			}
-		case reflect.Int64:
-			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
-				intval, err := strconv.ParseInt(v.Value, 10, 64)
-				if err != nil {
-					log.Printf("WARNING Field %s value %s could not be converted to int64: %s", fieldName, v.Value, err)
-					return nil
-				}
-				return intval
-			} else {
-				log.Printf("WARNING Field %s was not castable to a number", fieldName)
-				return nil
-			}
-		case reflect.Float32:
-			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
-				intval, err := strconv.ParseFloat(v.Value, 32)
-				if err != nil {
-					log.Printf("WARNING Field %s value %s could not be converted to float32: %s", fieldName, v.Value, err)
-					return nil
-				}
-				return float32(intval)
-			} else {
-				log.Printf("WARNING Field %s was not castable to a number", fieldName)
-				return nil
-			}
-		case reflect.Bool:
-			if v, isRightType := dynamoValue.(*types.AttributeValueMemberBOOL); isRightType {
-				return v.Value
-			} else {
-				log.Printf("WARNING Field %s was not castable to a bool", fieldName)
-				return nil
-			}
-		default:
-			log.Printf("WARNING Field %s has a type of %s which is not handled", fieldName, reflect.TypeOf(dynamoValue))
-			return nil
-		}
-	} else {
-		if nullable {
-			switch t {
-			case reflect.String:
-				return ""
-			case reflect.Int32:
-				return int32(0)
-			case reflect.Int64:
-				return int64(0)
-			case reflect.Float32:
-				return float32(0)
-			case reflect.Bool:
-				return false
-			default:
-				return nil
-			}
-		} else {
-			log.Printf("WARNING Field %s does not exist on the incoming record", fieldName)
-			return nil
-		}
-	}
-}
-
-/*
 EncodingFromDynamo takes a RawDynamoRecord (aka map of string -> dynamo value) and marshals it into a EncodingFromDynamo
 structure.  If we can't validate the structure an error is returned instead.
 Arguments: - rec - pointer to a raw dynamo record
@@ -138,31 +49,31 @@ func EncodingFromDynamo(rec *RawDynamoRecord) (result *Encoding, e error) {
 		}
 	}()
 
-	lastUpdateTime, err := time.Parse(time.RFC3339, extractContentResultField(rec, "lastupdate", reflect.String, false).(string))
+	lastUpdateTime, err := time.Parse(time.RFC3339, extractDynamoField(rec, "lastupdate", reflect.String, false).(string))
 	if err != nil {
 		log.Printf("WARNING Field 'lastupdate' is not a valid timestamp: %s", err)
 		return nil, errors.New("invalid timestamp")
 	}
 
 	newRecord := &Encoding{
-		EncodingId:  extractContentResultField(rec, "encodingid", reflect.Int32, false).(int32),
-		ContentId:   extractContentResultField(rec, "contentid", reflect.Int32, false).(int32),
-		Url:         extractContentResultField(rec, "url", reflect.String, false).(string),
-		Format:      extractContentResultField(rec, "format", reflect.String, false).(string),
-		Mobile:      extractContentResultField(rec, "mobile", reflect.Bool, false).(bool),
-		Multirate:   extractContentResultField(rec, "multirate", reflect.Bool, false).(bool),
-		VCodec:      extractContentResultField(rec, "vcodec", reflect.String, true).(string),
-		ACodec:      extractContentResultField(rec, "acodec", reflect.String, true).(string),
-		VBitrate:    extractContentResultField(rec, "vbitrate", reflect.Int32, true).(int32),
-		ABitrate:    extractContentResultField(rec, "abitrate", reflect.Int32, true).(int32),
+		EncodingId:  extractDynamoField(rec, "encodingid", reflect.Int32, false).(int32),
+		ContentId:   extractDynamoField(rec, "contentid", reflect.Int32, false).(int32),
+		Url:         extractDynamoField(rec, "url", reflect.String, false).(string),
+		Format:      extractDynamoField(rec, "format", reflect.String, false).(string),
+		Mobile:      extractDynamoField(rec, "mobile", reflect.Bool, false).(bool),
+		Multirate:   extractDynamoField(rec, "multirate", reflect.Bool, false).(bool),
+		VCodec:      extractDynamoField(rec, "vcodec", reflect.String, true).(string),
+		ACodec:      extractDynamoField(rec, "acodec", reflect.String, true).(string),
+		VBitrate:    extractDynamoField(rec, "vbitrate", reflect.Int32, true).(int32),
+		ABitrate:    extractDynamoField(rec, "abitrate", reflect.Int32, true).(int32),
 		LastUpdate:  lastUpdateTime,
-		FrameWidth:  extractContentResultField(rec, "frame_width", reflect.Int32, false).(int32),
-		FrameHeight: extractContentResultField(rec, "frame_height", reflect.Int32, false).(int32),
-		Duration:    extractContentResultField(rec, "duration", reflect.Float32, false).(float32),
-		FileSize:    extractContentResultField(rec, "file_size", reflect.Int64, false).(int64),
-		FCSID:       extractContentResultField(rec, "fcs_id", reflect.String, true).(string),
-		OctopusId:   extractContentResultField(rec, "octopus_id", reflect.Int32, true).(int32),
-		Aspect:      extractContentResultField(rec, "aspect", reflect.String, false).(string),
+		FrameWidth:  extractDynamoField(rec, "frame_width", reflect.Int32, false).(int32),
+		FrameHeight: extractDynamoField(rec, "frame_height", reflect.Int32, false).(int32),
+		Duration:    extractDynamoField(rec, "duration", reflect.Float32, false).(float32),
+		FileSize:    extractDynamoField(rec, "file_size", reflect.Int64, false).(int64),
+		FCSID:       extractDynamoField(rec, "fcs_id", reflect.String, true).(string),
+		OctopusId:   extractDynamoField(rec, "octopus_id", reflect.Int32, true).(int32),
+		Aspect:      extractDynamoField(rec, "aspect", reflect.String, false).(string),
 	}
 
 	return newRecord, nil

--- a/common/model_encoding.go
+++ b/common/model_encoding.go
@@ -62,6 +62,18 @@ func extractContentResultField(rec *RawDynamoRecord, fieldName string, t reflect
 				log.Printf("WARNING Field %s was not castable to a number", fieldName)
 				return nil
 			}
+		case reflect.Int64:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseInt(v.Value, 10, 64)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to int64: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return intval
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
 		case reflect.Float32:
 			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
 				intval, err := strconv.ParseFloat(v.Value, 32)

--- a/common/model_encoding.go
+++ b/common/model_encoding.go
@@ -1,0 +1,157 @@
+package common
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"log"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+/*
+Encoding represents a row from the `Encodings` table
+*/
+type Encoding struct {
+	EncodingId  int32     `json:"encoding_id"` //NOT NULL
+	ContentId   int32     `json:"content_id"`  //NOT NULL
+	Url         string    `json:"url"`         //NOT NULL
+	Format      string    `json:"format"`      //NOT NULL
+	Mobile      bool      `json:"mobile"`      //NOT NULL
+	Multirate   bool      `json:"multirate"`   //NOT NULL
+	VCodec      string    `json:"vcodec"`
+	ACodec      string    `json:"acodec"`
+	VBitrate    int32     `json:"vbitrate"`
+	ABitrate    int32     `json:"abitrate"`
+	LastUpdate  time.Time `json:"last_update"`  //NOT NULL, defaults to current time
+	FrameWidth  int32     `json:"frame_width"`  //NOT NULL
+	FrameHeight int32     `json:"frame_height"` //NOT NULL
+	Duration    float32   `json:"duration"`     //NOT NULL
+	FileSize    int64     `json:"file_size"`    //NOT NULL
+	FCSID       string    `json:"fcs_id"`       //NOT NULL
+	OctopusId   int32     `json:"octopus_id"`   //NOT NULL aka 'title id'
+	Aspect      string    `json:"aspect"`       //NOT NULL
+}
+
+/*
+extractContentResultField is an internal method that grabs the relevant field from Dynamodb, casts it to the right type
+and returns it as an interface.
+
+The return value is `nil` if either the field does not exist or is the wrong type.
+If a value is returned it should always be castable to the type given in the `t` parameter without further checks
+*/
+func extractContentResultField(rec *RawDynamoRecord, fieldName string, t reflect.Kind, nullable bool) interface{} {
+	if dynamoValue, valueExists := (*rec)[fieldName]; valueExists {
+		switch t {
+		case reflect.String:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberS); isRightType {
+				return v.Value
+			} else {
+				log.Printf("WARNING Field %s was not castable to a string", fieldName)
+				return nil
+			}
+		case reflect.Int32:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseInt(v.Value, 10, 32)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to int32: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return int32(intval)
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
+		case reflect.Float32:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberN); isRightType {
+				intval, err := strconv.ParseFloat(v.Value, 32)
+				if err != nil {
+					log.Printf("WARNING Field %s value %s could not be converted to float32: %s", fieldName, v.Value, err)
+					return nil
+				}
+				return float32(intval)
+			} else {
+				log.Printf("WARNING Field %s was not castable to a number", fieldName)
+				return nil
+			}
+		case reflect.Bool:
+			if v, isRightType := dynamoValue.(*types.AttributeValueMemberBOOL); isRightType {
+				return v.Value
+			} else {
+				log.Printf("WARNING Field %s was not castable to a bool", fieldName)
+				return nil
+			}
+		default:
+			log.Printf("WARNING Field %s has a type of %s which is not handled", fieldName, reflect.TypeOf(dynamoValue))
+			return nil
+		}
+	} else {
+		if nullable {
+			switch t {
+			case reflect.String:
+				return ""
+			case reflect.Int32:
+				return int32(0)
+			case reflect.Int64:
+				return int64(0)
+			case reflect.Float32:
+				return float32(0)
+			case reflect.Bool:
+				return false
+			default:
+				return nil
+			}
+		} else {
+			log.Printf("WARNING Field %s does not exist on the incoming record", fieldName)
+			return nil
+		}
+	}
+}
+
+/*
+EncodingFromDynamo takes a RawDynamoRecord (aka map of string -> dynamo value) and marshals it into a EncodingFromDynamo
+structure.  If we can't validate the structure an error is returned instead.
+Arguments: - rec - pointer to a raw dynamo record
+Returns:
+- pointer to the created ContentResult or nil on error
+- nil or an `error` if an error occurs
+*/
+func EncodingFromDynamo(rec *RawDynamoRecord) (result *Encoding, e error) {
+	defer func() {
+		//we allow the routine to panic if the typecast below fails then recover it here and return an error.
+		//the underlying cause should have been logged out already.
+		if r := recover(); r != nil {
+			result = nil
+			e = errors.New("the given record is not a ContentResult")
+		}
+	}()
+
+	lastUpdateTime, err := time.Parse(time.RFC3339, extractContentResultField(rec, "lastupdate", reflect.String, false).(string))
+	if err != nil {
+		log.Printf("WARNING Field 'lastupdate' is not a valid timestamp: %s", err)
+		return nil, errors.New("invalid timestamp")
+	}
+
+	newRecord := &Encoding{
+		EncodingId:  extractContentResultField(rec, "encodingid", reflect.Int32, false).(int32),
+		ContentId:   extractContentResultField(rec, "contentid", reflect.Int32, false).(int32),
+		Url:         extractContentResultField(rec, "url", reflect.String, false).(string),
+		Format:      extractContentResultField(rec, "format", reflect.String, false).(string),
+		Mobile:      extractContentResultField(rec, "mobile", reflect.Bool, false).(bool),
+		Multirate:   extractContentResultField(rec, "multirate", reflect.Bool, false).(bool),
+		VCodec:      extractContentResultField(rec, "vcodec", reflect.String, true).(string),
+		ACodec:      extractContentResultField(rec, "acodec", reflect.String, true).(string),
+		VBitrate:    extractContentResultField(rec, "vbitrate", reflect.Int32, true).(int32),
+		ABitrate:    extractContentResultField(rec, "abitrate", reflect.Int32, true).(int32),
+		LastUpdate:  lastUpdateTime,
+		FrameWidth:  extractContentResultField(rec, "frame_width", reflect.Int32, false).(int32),
+		FrameHeight: extractContentResultField(rec, "frame_height", reflect.Int32, false).(int32),
+		Duration:    extractContentResultField(rec, "duration", reflect.Float32, false).(float32),
+		FileSize:    extractContentResultField(rec, "file_size", reflect.Int64, false).(int64),
+		FCSID:       extractContentResultField(rec, "fcs_id", reflect.String, true).(string),
+		OctopusId:   extractContentResultField(rec, "octopus_id", reflect.Int32, true).(int32),
+		Aspect:      extractContentResultField(rec, "aspect", reflect.String, false).(string),
+	}
+
+	return newRecord, nil
+}

--- a/common/model_encoding_test.go
+++ b/common/model_encoding_test.go
@@ -1,0 +1,194 @@
+package common
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"testing"
+	"time"
+)
+
+/*
+Tests that a valid record can be decoded
+*/
+func TestEncodingFromDynamo(t *testing.T) {
+	testrecord := &RawDynamoRecord{
+		"encodingid":   &types.AttributeValueMemberN{Value: "1234"},
+		"contentid":    &types.AttributeValueMemberN{Value: "2345"},
+		"url":          &types.AttributeValueMemberS{Value: "http://some/encoding/urk"},
+		"format":       &types.AttributeValueMemberS{Value: "video/mp4"},
+		"mobile":       &types.AttributeValueMemberBOOL{Value: false},
+		"multirate":    &types.AttributeValueMemberBOOL{Value: false},
+		"vcodec":       &types.AttributeValueMemberS{Value: "h264"},
+		"acodec":       &types.AttributeValueMemberS{Value: "aac"},
+		"lastupdate":   &types.AttributeValueMemberS{Value: "2016-02-03T04:05:06Z"},
+		"frame_width":  &types.AttributeValueMemberN{Value: "1280"},
+		"frame_height": &types.AttributeValueMemberN{Value: "720"},
+		"duration":     &types.AttributeValueMemberN{Value: "123.456"},
+		"file_size":    &types.AttributeValueMemberN{Value: "567890123"},
+		"fcs_id":       &types.AttributeValueMemberS{Value: "9999998"},
+		"octopus_id":   &types.AttributeValueMemberN{Value: "55543"},
+		"aspect":       &types.AttributeValueMemberS{Value: "16:9"},
+	}
+
+	result, err := EncodingFromDynamo(testrecord)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	expectedUpdateTime, _ := time.Parse(time.RFC3339, "2016-02-03T04:05:06Z")
+
+	if result.EncodingId != 1234 {
+		t.Errorf("Unexpected encoding id %d", result.EncodingId)
+	}
+	if result.ContentId != 2345 {
+		t.Errorf("Unexpected content id %d", result.ContentId)
+	}
+	if result.Url != "http://some/encoding/urk" {
+		t.Errorf("Unexpected url '%s'", result.Url)
+	}
+	if result.Format != "video/mp4" {
+		t.Errorf("Unexpected format '%s'", result.Format)
+	}
+	if result.Mobile != false {
+		t.Errorf("Unexpected mobile result: %v", result.Mobile)
+	}
+	if result.Multirate != false {
+		t.Errorf("Unexpected multirate result %v", result.Multirate)
+	}
+	if result.VCodec != "h264" {
+		t.Errorf("Unexpected vcodec %s", result.VCodec)
+	}
+	if result.ACodec != "aac" {
+		t.Errorf("Unexpected acodec %s", result.ACodec)
+	}
+	if result.LastUpdate != expectedUpdateTime {
+		t.Errorf("Unexpected update time %s", result.LastUpdate.Format(time.RFC3339))
+	}
+	if result.FrameWidth != 1280 {
+		t.Errorf("Unexpected frame width %d", result.FrameWidth)
+	}
+	if result.FrameHeight != 720 {
+		t.Errorf("Unexpected frame height %d", result.FrameHeight)
+	}
+	if result.Duration != 123.456 {
+		t.Errorf("Unexpected duration %f", result.Duration)
+	}
+	if result.FileSize != 567890123 {
+		t.Errorf("Unexpected file size %d", result.FileSize)
+	}
+	if result.FCSID != "9999998" {
+		t.Errorf("Unexpected FCS ID %s", result.FCSID)
+	}
+	if result.OctopusId != 55543 {
+		t.Errorf("Unexpected Octopus ID")
+	}
+	if result.Aspect != "16:9" {
+		t.Errorf("Unexpected aspect ratio %s", result.Aspect)
+	}
+}
+
+/*
+test that a record missing optional fields can still be decoded
+*/
+func TestEncodingFromDynamoMissingOptional(t *testing.T) {
+	testrecord := &RawDynamoRecord{
+		"encodingid":   &types.AttributeValueMemberN{Value: "1234"},
+		"contentid":    &types.AttributeValueMemberN{Value: "2345"},
+		"url":          &types.AttributeValueMemberS{Value: "http://some/encoding/urk"},
+		"format":       &types.AttributeValueMemberS{Value: "video/mp4"},
+		"mobile":       &types.AttributeValueMemberBOOL{Value: false},
+		"multirate":    &types.AttributeValueMemberBOOL{Value: false},
+		"lastupdate":   &types.AttributeValueMemberS{Value: "2016-02-03T04:05:06Z"},
+		"frame_width":  &types.AttributeValueMemberN{Value: "1280"},
+		"frame_height": &types.AttributeValueMemberN{Value: "720"},
+		"duration":     &types.AttributeValueMemberN{Value: "123.456"},
+		"file_size":    &types.AttributeValueMemberN{Value: "567890123"},
+		"fcs_id":       &types.AttributeValueMemberS{Value: "9999998"},
+		"octopus_id":   &types.AttributeValueMemberN{Value: "55543"},
+		"aspect":       &types.AttributeValueMemberS{Value: "16:9"},
+	}
+
+	result, err := EncodingFromDynamo(testrecord)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	expectedUpdateTime, _ := time.Parse(time.RFC3339, "2016-02-03T04:05:06Z")
+
+	if result.EncodingId != 1234 {
+		t.Errorf("Unexpected encoding id %d", result.EncodingId)
+	}
+	if result.ContentId != 2345 {
+		t.Errorf("Unexpected content id %d", result.ContentId)
+	}
+	if result.Url != "http://some/encoding/urk" {
+		t.Errorf("Unexpected url '%s'", result.Url)
+	}
+	if result.Format != "video/mp4" {
+		t.Errorf("Unexpected format '%s'", result.Format)
+	}
+	if result.Mobile != false {
+		t.Errorf("Unexpected mobile result: %v", result.Mobile)
+	}
+	if result.Multirate != false {
+		t.Errorf("Unexpected multirate result %v", result.Multirate)
+	}
+	if result.LastUpdate != expectedUpdateTime {
+		t.Errorf("Unexpected update time %s", result.LastUpdate.Format(time.RFC3339))
+	}
+	if result.FrameWidth != 1280 {
+		t.Errorf("Unexpected frame width %d", result.FrameWidth)
+	}
+	if result.FrameHeight != 720 {
+		t.Errorf("Unexpected frame height %d", result.FrameHeight)
+	}
+	if result.Duration != 123.456 {
+		t.Errorf("Unexpected duration %f", result.Duration)
+	}
+	if result.FileSize != 567890123 {
+		t.Errorf("Unexpected file size %d", result.FileSize)
+	}
+	if result.FCSID != "9999998" {
+		t.Errorf("Unexpected FCS ID %s", result.FCSID)
+	}
+	if result.OctopusId != 55543 {
+		t.Errorf("Unexpected Octopus ID")
+	}
+	if result.Aspect != "16:9" {
+		t.Errorf("Unexpected aspect ratio %s", result.Aspect)
+	}
+}
+
+/*
+Tests that we fail if mandatory fields are missing
+*/
+func TestEncodingFromDynamoMissingMandatory(t *testing.T) {
+	testrecord := &RawDynamoRecord{
+		"encodingid":   &types.AttributeValueMemberN{Value: "1234"},
+		"contentid":    &types.AttributeValueMemberN{Value: "2345"},
+		"url":          &types.AttributeValueMemberS{Value: "http://some/encoding/urk"},
+		"mobile":       &types.AttributeValueMemberBOOL{Value: false},
+		"multirate":    &types.AttributeValueMemberBOOL{Value: false},
+		"vcodec":       &types.AttributeValueMemberS{Value: "h264"},
+		"acodec":       &types.AttributeValueMemberS{Value: "aac"},
+		"lastupdate":   &types.AttributeValueMemberS{Value: "2016-02-03T04:05:06Z"},
+		"frame_width":  &types.AttributeValueMemberN{Value: "1280"},
+		"frame_height": &types.AttributeValueMemberN{Value: "720"},
+		"duration":     &types.AttributeValueMemberN{Value: "123.456"},
+		"file_size":    &types.AttributeValueMemberN{Value: "567890123"},
+		"fcs_id":       &types.AttributeValueMemberS{Value: "9999998"},
+		"octopus_id":   &types.AttributeValueMemberN{Value: "55543"},
+		"aspect":       &types.AttributeValueMemberS{Value: "16:9"},
+	}
+
+	_, err := EncodingFromDynamo(testrecord)
+	if err == nil {
+		t.Error("Expected an error on an invalid record but got nothing")
+		t.FailNow()
+	}
+
+	if err.Error() != "the given record is not a ContentResult" {
+		t.Errorf("Unexpected error string on invalid record: %s", err.Error())
+	}
+}

--- a/common/model_mime_equivalent.go
+++ b/common/model_mime_equivalent.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"errors"
+	"reflect"
+)
+
+type MimeEquivalent struct {
+	Id             int32
+	RealName       string
+	MimeEquivalent string
+}
+
+func MimeEquivalentFromDynamo(rec *RawDynamoRecord) (result *MimeEquivalent, e error) {
+	defer func() {
+		//we allow the routine to panic if the typecast below fails then recover it here and return an error.
+		//the underlying cause should have been logged out already.
+		if r := recover(); r != nil {
+			result = nil
+			e = errors.New("the given record is not a ContentResult")
+		}
+	}()
+
+	newRecord := &MimeEquivalent{
+		Id:             extractDynamoField(rec, "id", reflect.Int32, true).(int32),
+		RealName:       extractDynamoField(rec, "real_name", reflect.String, false).(string),
+		MimeEquivalent: extractDynamoField(rec, "mime_equivalent", reflect.String, false).(string),
+	}
+	return newRecord, nil
+}

--- a/common/model_mime_equivalent_test.go
+++ b/common/model_mime_equivalent_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"testing"
+)
+
+func TestMimeEquivalentFromDynamo(t *testing.T) {
+	rec := &RawDynamoRecord{
+		"real_name":       &types.AttributeValueMemberS{Value: "video/m3u8"},
+		"mime_equivalent": &types.AttributeValueMemberS{Value: "application/x-m3u8"},
+	}
+
+	result, err := MimeEquivalentFromDynamo(rec)
+	if err != nil {
+		t.Errorf("Got unexpected error: %s", err)
+		t.FailNow()
+	}
+
+	if result.MimeEquivalent != "application/x-m3u8" {
+		t.Errorf("Got incorrect MimeEquivalent '%s'", result.MimeEquivalent)
+	}
+
+	if result.RealName != "video/m3u8" {
+		t.Errorf("Got incorrect RealName '%s'", result.RealName)
+	}
+}

--- a/common/model_posterframes.go
+++ b/common/model_posterframes.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"errors"
+	"reflect"
+)
+
+type PosterFrame struct {
+	PosterId   int32  `json:"poster_id"`
+	EncodingId int32  `json:"encoding_id"`
+	ContentId  int32  `json:"content_id"`
+	PosterUrl  string `json:"poster_url"`
+	MimeType   string `json:"mime_type"`
+}
+
+func PosterFrameFromDynamo(rec *RawDynamoRecord) (result *PosterFrame, e error) {
+	defer func() {
+		//we allow the routine to panic if the typecast below fails then recover it here and return an error.
+		//the underlying cause should have been logged out already.
+		if r := recover(); r != nil {
+			result = nil
+			e = errors.New("the given record is not a ContentResult")
+		}
+	}()
+
+	newRecord := &PosterFrame{
+		PosterId:   extractDynamoField(rec, "posterid", reflect.Int32, false).(int32),
+		EncodingId: extractDynamoField(rec, "encodingid", reflect.Int32, false).(int32),
+		ContentId:  extractDynamoField(rec, "contentid", reflect.Int32, false).(int32),
+		PosterUrl:  extractDynamoField(rec, "poster_url", reflect.String, false).(string),
+		MimeType:   extractDynamoField(rec, "mime_type", reflect.String, false).(string),
+	}
+	return newRecord, nil
+}

--- a/common/model_posterframes_test.go
+++ b/common/model_posterframes_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"testing"
+)
+
+func TestPosterFrameFromDynamo(t *testing.T) {
+	rec := &RawDynamoRecord{
+		"posterid":   &types.AttributeValueMemberN{Value: "11111"},
+		"encodingid": &types.AttributeValueMemberN{Value: "22222"},
+		"contentid":  &types.AttributeValueMemberN{Value: "33333"},
+		"poster_url": &types.AttributeValueMemberS{Value: "https://some/poster/url"},
+		"mime_type":  &types.AttributeValueMemberS{Value: "image/jpeg"},
+	}
+
+	result, err := PosterFrameFromDynamo(rec)
+	if err != nil {
+		t.Errorf("Got unexpected error from PosterFrameFromDynamo: %s", err)
+		t.FailNow()
+	}
+
+	if result.PosterId != 11111 {
+		t.Errorf("Got unexpected result for PosterId: %d", result.PosterId)
+	}
+	if result.EncodingId != 22222 {
+		t.Errorf("Got unexpected result for EncodingId: %d", result.EncodingId)
+	}
+	if result.ContentId != 33333 {
+		t.Errorf("Got unexpected result for ContentId: %d", result.ContentId)
+	}
+	if result.PosterUrl != "https://some/poster/url" {
+		t.Errorf("Got unexpected result for poster url: %s", result.PosterUrl)
+	}
+	if result.MimeType != "image/jpeg" {
+		t.Errorf("Got unexpected result for mime type: %s", result.MimeType)
+	}
+}

--- a/migration/Makefile
+++ b/migration/Makefile
@@ -1,7 +1,7 @@
 all: migration.linuxx64 migration.linuxarm migration.macx64 migration.macarm
 
 clean:
-	rm -f migration.linux* migration.mac*
+	rm -f migration.linux* migration.mac* migration
 
 migration.macx64: main.go dynamo_writer.go async_db_reader.go
 	GOOS=darwin GOARCH=amd64 go build -o migration.macx64

--- a/migration/async_db_reader.go
+++ b/migration/async_db_reader.go
@@ -125,7 +125,7 @@ func AsyncDbReader(db *sql.DB, tableToScan string) (chan GeneralRecord, chan err
 					if stringValue != "" {
 						floatValue, err := strconv.ParseFloat(stringValue, 64)
 						if err != nil {
-							log.Printf("WARNING invalid floag value %s: %s", floatValue, err)
+							log.Printf("WARNING invalid float value %f: %s", floatValue, err)
 						} else {
 							rec[col] = floatValue
 						}

--- a/referenceapi/Makefile
+++ b/referenceapi/Makefile
@@ -15,4 +15,4 @@ deploy: referenceapi.zip
 	../ci-scripts/upload-and-deploy.sh "referenceapi.zip" "${APP}-References"
 
 clean:
-	rm -f referenceapi referenceapi.zip
+	rm -f referenceapi referenceapi.zip published-version.json


### PR DESCRIPTION
## What does this change?

Closes GP-707.  Implements a data model for the `Encodings` table and a function to marshal data from DynamoDB

## How to test
Tested in automated tests
