### PR TITLE
New Argument for Migration Executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: referenceapi upload clean deploy
+.PHONY: referenceapi upload clean deploy migration
 
 all: referenceapi migration
 


### PR DESCRIPTION
## What does this change?

Adds a new argument to the migration executable called nullable-fields that accepts a comma seperated list of fields that can be empty.