### PR TITLE
Tweak the API paths to match the existing implementation

### DIFF
--- a/infra/apigateway_base.yaml
+++ b/infra/apigateway_base.yaml
@@ -52,7 +52,12 @@ Resources:
                   - logs:GetLogEvents
                   - logs:FilterLogEvents
                 Resource: "*"
-
+  BaseResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref RestAPI
+      PathPart: interactivevideos
+      ParentId: !GetAtt RestAPI.RootResourceId
 
   ApiGatewayAccount:
     Type: AWS::ApiGateway::Account
@@ -70,6 +75,11 @@ Outputs:
     Value: !GetAtt RestAPI.RootResourceId
     Export:
       Name: !Sub ${AWS::StackName}-RestAPIRoot
+  InteractiveVideosBase:
+    Description: Base resource for InteractiveVideos
+    Value: !Ref BaseResource
+    Export:
+      Name: !Sub ${AWS::StackName}-InteractiveVidsBase
   GWAccount:
     Description: API Gateway Account
     Value: !Ref ApiGatewayAccount

--- a/infra/endpoints.yaml
+++ b/infra/endpoints.yaml
@@ -303,9 +303,9 @@ Resources:
     Properties:
       RestApiId: !ImportValue
         'Fn::Sub': ${APIGatewayStack}-RestAPI
-      PathPart: reference
+      PathPart: reference.php
       ParentId: !ImportValue
-        'Fn::Sub': ${APIGatewayStack}-RestAPIRoot
+        'Fn::Sub': ${APIGatewayStack}-InteractiveVidsBase
   ReferenceAPIEndpoint: #this creates the entry in the Rest API for the GET handler
     Type: AWS::ApiGateway::Method
     DependsOn:


### PR DESCRIPTION
## What does this change?

Changes the API paths to match the existing implementation, e.g. `reference` -> `interactivevideos/reference.php`.

## How to test
Once deployed, transposing `code.multimedia.guardianapis.com` for `multimedia.guardianapis.com` should result in routing to the correct place (for the `reference` endpoint at any rate)
