### PR TITLE
Feature / MIME equivalents

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -31,6 +31,7 @@ type Config interface {
 	GetDynamoClient() *dynamodb.Client
 	IdMappingTable() string
 	EncodingsTablePtr() *string
+	MimeEquivalentsTablePtr() *string
 }
 
 /*
@@ -84,4 +85,8 @@ func (c *ConfigImpl) IdMappingTable() string {
 
 func (c *ConfigImpl) EncodingsTablePtr() *string {
 	return aws.String(c.DyanmoContentTable)
+}
+
+func (c *ConfigImpl) MimeEquivalentsTablePtr() *string {
+	return aws.String(c.MimeEquivalentsTable)
 }

--- a/common/config_mocks.go
+++ b/common/config_mocks.go
@@ -1,6 +1,9 @@
 package common
 
-import "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
 
 type ConfigMock struct {
 	IdMappingTableVal string
@@ -18,4 +21,8 @@ func (c *ConfigMock) IdMappingTable() string {
 func (c *ConfigMock) EncodingsTablePtr() *string {
 	copied := c.EncodingsTableVal
 	return &copied
+}
+
+func (c *ConfigMock) MimeEquivalentsTablePtr() *string {
+	return aws.String("mime-equivalents")
 }

--- a/common/content_filter.go
+++ b/common/content_filter.go
@@ -30,35 +30,44 @@ Returns:
 - bool - true if the encoding should pass and false if it should not
 */
 func TestEncoding(encoding *Encoding, formats *[]string, need_mobile bool, minbitrate int32, maxbitrate int32, minheight int32, maxheight int32, minwidth int32, maxwidth int32) bool {
+	log.Printf("DEBUG ContentFilter.TestEncoding encoding's format is %s, potential formats list is %v", encoding.Format, *formats)
 	if len(*formats) > 0 && !isStringInList(&encoding.Format, formats) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on format", encoding.Url)
 		return false
 	}
 
-	if encoding.Mobile != need_mobile {
+	if need_mobile && !encoding.Mobile { //if need_mobile is false that means "don't discount on basis of mobile flag"
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on mobile", encoding.Url)
 		return false
 	}
 
 	if (encoding.VBitrate < minbitrate) && (minbitrate != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on min vbitrate", encoding.Url)
 		return false
 	}
 
 	if (encoding.VBitrate > maxbitrate) && (maxbitrate != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on max vbitrate", encoding.Url)
 		return false
 	}
 
 	if (encoding.FrameHeight < minheight) && (minheight != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on min height", encoding.Url)
 		return false
 	}
 
 	if (encoding.FrameHeight > maxheight) && (maxheight != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on max height", encoding.Url)
 		return false
 	}
 
 	if (encoding.FrameWidth < minwidth) && (minwidth != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on min width", encoding.Url)
 		return false
 	}
 
 	if (encoding.FrameWidth > maxwidth) && (maxwidth != 0) {
+		log.Printf("DEBUG ContentFilter.TestEncoding %s discounted on max width", encoding.Url)
 		return false
 	}
 

--- a/common/content_filter.go
+++ b/common/content_filter.go
@@ -1,6 +1,18 @@
 package common
 
 /*
+isStringInList will return `true` if the given string is in the given list or `false` otherwise
+*/
+func isStringInList(needle *string, haystack *[]string) bool {
+	for _, s := range *haystack {
+		if s == *needle {
+			return true
+		}
+	}
+	return false
+}
+
+/*
 TestEncoding Output true if the encoding should pass the filter and false if it should not
 Arguments:
 - encoding - A pointer to Encoding
@@ -15,8 +27,8 @@ Arguments:
 Returns:
 - bool - true if the encoding should pass and false if it should not
 */
-func TestEncoding(encoding *Encoding, format string, need_mobile bool, minbitrate int32, maxbitrate int32, minheight int32, maxheight int32, minwidth int32, maxwidth int32) bool {
-	if (encoding.Format != format) && (format != "") {
+func TestEncoding(encoding *Encoding, formats *[]string, need_mobile bool, minbitrate int32, maxbitrate int32, minheight int32, maxheight int32, minwidth int32, maxwidth int32) bool {
+	if len(*formats) > 0 && !isStringInList(&encoding.Format, formats) {
 		return false
 	}
 
@@ -55,7 +67,7 @@ func TestEncoding(encoding *Encoding, format string, need_mobile bool, minbitrat
 ContentFilter Output a pointer to a ContentResult object after filtering an array of pointers to Encoding based on the other arguments
 Arguments:
 - encodings - An array of pointers to Encoding
-- format - The required format
+- formats - An array of 0 or more strings representing a MIME type. If this is non-zero-length then at least one of the format strings must match.
 - need_mobile - Set this to true if a mobile encoding is required
 - minbitrate - The minimum required bit rate
 - maxbitrate - The maximum required bit rate
@@ -66,10 +78,10 @@ Arguments:
 Returns:
 - ContentResult object populated with the best pointer to an Encoding
 */
-func ContentFilter(encodings []*Encoding, format string, need_mobile bool, minbitrate int32, maxbitrate int32, minheight int32, maxheight int32, minwidth int32, maxwidth int32) *ContentResult {
+func ContentFilter(encodings []*Encoding, formats *[]string, need_mobile bool, minbitrate int32, maxbitrate int32, minheight int32, maxheight int32, minwidth int32, maxwidth int32) *ContentResult {
 	var encodingsToReturn []*Encoding
 	for _, element := range encodings {
-		if TestEncoding(element, format, need_mobile, minbitrate, maxbitrate, minheight, maxheight, minwidth, maxwidth) {
+		if TestEncoding(element, formats, need_mobile, minbitrate, maxbitrate, minheight, maxheight, minwidth, maxwidth) {
 			encodingsToReturn = append(encodingsToReturn, element)
 		}
 	}

--- a/common/content_filter.go
+++ b/common/content_filter.go
@@ -1,5 +1,7 @@
 package common
 
+import "log"
+
 /*
 isStringInList will return `true` if the given string is in the given list or `false` otherwise
 */
@@ -86,6 +88,10 @@ func ContentFilter(encodings []*Encoding, formats *[]string, need_mobile bool, m
 		}
 	}
 
+	log.Printf("ContentFilter: %d records remaining after filter", len(encodingsToReturn))
+	for _, e := range encodingsToReturn {
+		log.Printf("\t%v", e)
+	}
 	if len(encodingsToReturn) == 0 {
 		return nil
 	} else {

--- a/common/content_filter_test.go
+++ b/common/content_filter_test.go
@@ -29,6 +29,19 @@ func TestContentFilterFormat(t *testing.T) {
 }
 
 /*
+Should return data that has _any_ of the given formats specified
+*/
+func TestContentFilterAlternateFormat(t *testing.T) {
+	formats := []string{"socks", "test"}
+	testarray := []*Encoding{{1, 1, "test", "test2", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
+	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, "", ""}
+	result := ContentFilter(testarray, &formats, false, 1, 1, 1, 1, 1, 1)
+	if !reflect.DeepEqual(result, expectedOutput) {
+		t.Errorf("Unexpected output")
+	}
+}
+
+/*
 Tests that the code which removes records with the wrong mobile setting works
 */
 func TestContentFilterMobile(t *testing.T) {

--- a/common/content_filter_test.go
+++ b/common/content_filter_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"reflect"
 	"testing"
 	"time"
@@ -129,5 +130,11 @@ func TestContentFilterMaxWidth(t *testing.T) {
 	result := ContentFilter(testarray, &formats, false, 3000, 6000, 800, 2000, 900, 2000)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
+	}
+}
+
+func TestIsStringInList(t *testing.T) {
+	if isStringInList(aws.String("audio/mpeg"), &[]string{"audio/mpeg", "audio/mp3"}) == false {
+		t.Error("isStringInList failed to detect 'audio/mpeg' in a string")
 	}
 }

--- a/common/content_filter_test.go
+++ b/common/content_filter_test.go
@@ -19,9 +19,10 @@ func ReturnCorrectTimeObject() time.Time {
 Tests that the code which removes records with the wrong format works
 */
 func TestContentFilterFormat(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test2", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 1, 1, 1, 1, 1, 1)
+	result := ContentFilter(testarray, &formats, false, 1, 1, 1, 1, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -31,9 +32,10 @@ func TestContentFilterFormat(t *testing.T) {
 Tests that the code which removes records with the wrong mobile setting works
 */
 func TestContentFilterMobile(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", true, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", true, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", true, 1, 1, 1, 1, 1, 1)
+	result := ContentFilter(testarray, &formats, true, 1, 1, 1, 1, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -43,9 +45,10 @@ func TestContentFilterMobile(t *testing.T) {
 Tests that the code which removes records with too low a bit rate works
 */
 func TestContentFilterMinBitRate(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 1, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 1, 1, 1, 1)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 1, 1, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -55,9 +58,10 @@ func TestContentFilterMinBitRate(t *testing.T) {
 Tests that the code which removes records with too high a bit rate works
 */
 func TestContentFilterMaxBitRate(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 8000, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 1, 1, 1, 1)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 1, 1, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -67,9 +71,10 @@ func TestContentFilterMaxBitRate(t *testing.T) {
 Tests that the code which removes records with too low a frame height works
 */
 func TestContentFilterMinHeight(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1000, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 4000, 1, ReturnCorrectTimeObject(), 1, 1, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1000, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 800, 2000, 1, 1)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 800, 2000, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -79,9 +84,10 @@ func TestContentFilterMinHeight(t *testing.T) {
 Tests that the code which removes records with too high a frame height works
 */
 func TestContentFilterMaxHeight(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1000, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 4000, 1, ReturnCorrectTimeObject(), 1, 4000, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1, 1000, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 800, 2000, 1, 1)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 800, 2000, 1, 1)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -91,9 +97,10 @@ func TestContentFilterMaxHeight(t *testing.T) {
 Tests that the code which removes records with too low a frame width works
 */
 func TestContentFilterMinWidth(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1000, 1000, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 4000, 1, ReturnCorrectTimeObject(), 800, 1000, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1000, 1000, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 800, 2000, 900, 2000)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 800, 2000, 900, 2000)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}
@@ -103,9 +110,10 @@ func TestContentFilterMinWidth(t *testing.T) {
 Tests that the code which removes records with too high a frame width works
 */
 func TestContentFilterMaxWidth(t *testing.T) {
+	formats := []string{"test"}
 	testarray := []*Encoding{{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1000, 1000, 4.0, 1, "test", 1, "test"}, {1, 1, "test", "test", false, false, "test", "test", 4000, 1, ReturnCorrectTimeObject(), 3000, 1000, 4.0, 1, "test", 1, "test"}}
 	expectedOutput := &ContentResult{Encoding{1, 1, "test", "test", false, false, "test", "test", 3557, 1, ReturnCorrectTimeObject(), 1000, 1000, 4.0, 1, "test", 1, "test"}, "", ""}
-	result := ContentFilter(testarray, "test", false, 3000, 6000, 800, 2000, 900, 2000)
+	result := ContentFilter(testarray, &formats, false, 3000, 6000, 800, 2000, 900, 2000)
 	if !reflect.DeepEqual(result, expectedOutput) {
 		t.Errorf("Unexpected output")
 	}

--- a/common/dynamo_ops.go
+++ b/common/dynamo_ops.go
@@ -128,7 +128,7 @@ func _marshalResponseToSortedEncodings(response *dynamodb.QueryOutput) ([]*Encod
 	}
 
 	sort.Slice(encodings, func(i int, j int) bool {
-		return encodings[i].VBitrate < encodings[j].VBitrate
+		return encodings[i].VBitrate > encodings[j].VBitrate
 	})
 	return encodings, nil
 }

--- a/common/dynamo_ops.go
+++ b/common/dynamo_ops.go
@@ -128,7 +128,7 @@ func _marshalResponseToSortedEncodings(response *dynamodb.QueryOutput) ([]*Encod
 	}
 
 	sort.Slice(encodings, func(i int, j int) bool {
-		return encodings[i].VBitrate > encodings[j].VBitrate
+		return encodings[i].VBitrate < encodings[j].VBitrate
 	})
 	return encodings, nil
 }

--- a/common/dynamo_ops_mocks.go
+++ b/common/dynamo_ops_mocks.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -68,4 +69,8 @@ func (ops *DynamoOpsMock) QueryIdMappings(ctx context.Context, indexName string,
 		coped := ops.IdMappingResult
 		return &coped, nil
 	}
+}
+
+func (ops *DynamoOpsMock) GetAllMimeEquivalents(ctx context.Context) ([]*MimeEquivalent, error) {
+	return nil, errors.New("not implemented in DynamoOpsMock")
 }

--- a/common/find_content.go
+++ b/common/find_content.go
@@ -47,7 +47,7 @@ func getFCSId(ctx context.Context, ops DynamoDbOps, contentId int32) (*string, e
 	}
 
 	for _, r := range *results {
-		if r != "" {
+		if r != "" && r != "ABSENT" {
 			finalResult := r
 			return &finalResult, nil
 		}

--- a/common/find_content.go
+++ b/common/find_content.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/aws/aws-lambda-go/events"
 	"log"
+	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -99,7 +100,7 @@ Returns:
 - a pointer to ContentResult on success
 - a pointer to APIGatewayProxyResponse on error. This can be passed back directly to the runtime.
 */
-func FindContent(ctx context.Context, queryStringParams *map[string]string, ops DynamoDbOps, config Config) (*ContentResult, *events.APIGatewayProxyResponse) {
+func FindContent(ctx context.Context, queryStringParams *map[string]string, ops DynamoDbOps, config Config, cache MimeEquivalentsCache) (*ContentResult, *events.APIGatewayProxyResponse) {
 	//FIXME: no memcache implementation yet, we'll see how necessary it actually is
 	idMapping, errResponse := getIDMapping(ctx, queryStringParams, ops, config)
 	if errResponse != nil {
@@ -147,15 +148,21 @@ func FindContent(ctx context.Context, queryStringParams *map[string]string, ops 
 	}
 
 	var filenameOverride string
-	var format string
+	var formats []string
 	if val, ok := (*queryStringParams)["format"]; ok {
 		var needOverride bool
 		filenameOverride, needOverride = HasDodgyM3U8Format(val)
+		var initialFormat string
 		if needOverride {
-			format = "video/m3u8" //in this case, the last part of the URL got overwritten by a filepath by dodgy iOS implementation. So we hard-fix it here.
+			initialFormat = "video/m3u8" //in this case, the last part of the URL got overwritten by a filepath by dodgy iOS implementation. So we hard-fix it here.
 		} else {
-			format = val //the format part was not messed around so just use it
+			initialFormat, err = url.QueryUnescape(val) //the format part was not messed around so just use it
+			if err != nil {
+				log.Printf("ERROR could not unescape requested format string %s: %s", val, err)
+				return nil, MakeResponseJson(400, GenericErrorBody("Invalid query"))
+			}
 		}
+		formats = cache.EquivalentsFor(initialFormat)
 	}
 
 	var need_mobile = false
@@ -201,7 +208,7 @@ func FindContent(ctx context.Context, queryStringParams *map[string]string, ops 
 		maxwidth = int32(parseIntOutput)
 	}
 
-	filteredContent := ContentFilter(contentToFilter, format, need_mobile, minbitrate, maxbitrate, minheight, maxheight, minwidth, maxwidth)
+	filteredContent := ContentFilter(contentToFilter, &formats, need_mobile, minbitrate, maxbitrate, minheight, maxheight, minwidth, maxwidth)
 	if filteredContent != nil {
 		_, allowInsecure := (*queryStringParams)["allow_insecure"]
 		filteredContent.Url = ForceHTTPS(filteredContent.Url, allowInsecure)
@@ -212,8 +219,10 @@ func FindContent(ctx context.Context, queryStringParams *map[string]string, ops 
 			log.Printf("WARNING GeneratePosterImageURL could not generate poster image URL for: %s, error: %s", filteredContent.Url, possiblePosterImageError)
 		}
 
-		filteredContent.RealMimeName = format //normally this is the format that was requested but it can be messed up by iOS
-		if filenameOverride != "" {           //we have a malformed request from iOS and must work around it
+		if len(formats) > 0 {
+			filteredContent.RealMimeName = formats[0] //normally this is the format that was requested but it can be messed up by iOS
+		}
+		if filenameOverride != "" { //we have a malformed request from iOS and must work around it
 			endOfURL := regexp.MustCompile(`/[^/]+$`)
 			filteredContent.Url = endOfURL.ReplaceAllString(filteredContent.Url, "/"+filenameOverride)
 		}

--- a/common/find_content_test.go
+++ b/common/find_content_test.go
@@ -28,7 +28,7 @@ func TestFindContentInvalidParams(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content != nil {
 		t.Error("FindContent returned content result for an invalid query")
 	}
@@ -64,7 +64,7 @@ func TestFindContentInvalidFilename(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content != nil {
 		t.Error("FindContent returned content result for an invalid filebase")
 	}
@@ -125,7 +125,7 @@ func TestFindContentValidFilename(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if errResponse != nil {
 		t.Errorf("FindContent returned an error '%v' for a valid filebase", errResponse)
 		t.FailNow()
@@ -199,7 +199,7 @@ func TestFindContentValidFilenameNotFound(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if errResponse == nil {
 		t.Errorf("FindContent returned no error for a file not found")
 		t.FailNow()
@@ -238,7 +238,7 @@ func TestFindContentInvalidOctopusId(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content != nil {
 		t.Error("FindContent returned content result for an invalid octid")
 	}
@@ -274,7 +274,7 @@ func TestFindContentAnotherInvalidOctopusId(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content != nil {
 		t.Error("FindContent returned content result for an invalid octid")
 	}
@@ -335,7 +335,7 @@ func TestFindContentValidOctid(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if errResponse != nil {
 		t.Errorf("FindContent returned an error '%v' for a valid octopusid", errResponse)
 		t.FailNow()
@@ -410,7 +410,7 @@ func TestFindContentFallback(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config)
+	content, errResponse := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if errResponse != nil {
 		t.Errorf("FindContent returned an error '%v' for a valid octopusid", errResponse)
 		t.FailNow()
@@ -482,7 +482,7 @@ func TestFindContentAllowInsecure(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, _ := FindContent(context.Background(), &fakeParams, ops, config)
+	content, _ := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content.Url != "http://url/to/content" {
 		t.Error("FindContent returned a URL not starting with http:")
 	}
@@ -532,7 +532,7 @@ func TestFindContentM3U8(t *testing.T) {
 		EncodingsTableVal: "encodings-table",
 	}
 
-	content, _ := FindContent(context.Background(), &fakeParams, ops, config)
+	content, _ := FindContent(context.Background(), &fakeParams, ops, config, &MimeEquivalentsCacheMock{})
 	if content.Url != "https://some.cdn/somefilename.m3u8" {
 		t.Errorf("Unexpected output: %s", content.Url)
 	}

--- a/common/mime_equivalents_cache.go
+++ b/common/mime_equivalents_cache.go
@@ -1,0 +1,50 @@
+package common
+
+import "context"
+
+type MimeEquivalentsCache interface {
+	/*
+		EquivalentsFor will return a list of _all_ known equivalents to the given MIME type (including itself).
+	*/
+	EquivalentsFor(input string) []string
+}
+
+type MimeEquivalentsCacheImpl struct {
+	loadedData map[string]string
+}
+
+func NewMimeEquivalentsCache(ctx context.Context, ops DynamoDbOps) (MimeEquivalentsCache, error) {
+	equivs, err := ops.GetAllMimeEquivalents(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := &MimeEquivalentsCacheImpl{
+		loadedData: make(map[string]string, 2*len(equivs)),
+	}
+
+	for _, equiv := range equivs {
+		cache.loadedData[equiv.RealName] = equiv.MimeEquivalent
+		cache.loadedData[equiv.MimeEquivalent] = equiv.RealName
+	}
+	return cache, nil
+}
+
+func (cache *MimeEquivalentsCacheImpl) EquivalentsFor(input string) []string {
+	result := []string{input}
+
+	if lookedUpEquivalent, haveEquiv := cache.loadedData[input]; haveEquiv {
+		result = append(result, lookedUpEquivalent)
+		return result
+	} else {
+		return result
+	}
+}
+
+type MimeEquivalentsCacheMock struct {
+}
+
+func (cache *MimeEquivalentsCacheMock) EquivalentsFor(input string) []string {
+	result := []string{input}
+	return result
+}

--- a/common/mime_equivalents_cache_test.go
+++ b/common/mime_equivalents_cache_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMimeEquivalentsCacheImpl_EquivalentsFor(t *testing.T) {
+	toTest := &MimeEquivalentsCacheImpl{
+		loadedData: map[string]string{
+			"video/m3u8":            "application/x-mpegURL",
+			"application/x-mpegURL": "video/m3u8",
+		},
+	}
+
+	m3u8result := toTest.EquivalentsFor("video/m3u8")
+	if !reflect.DeepEqual(m3u8result, []string{"video/m3u8", "application/x-mpegURL"}) {
+		t.Errorf("EquivalentsFor returned %v when we expected \"video/m3u8\", \"application/x-mpegURL\"", m3u8result)
+	}
+
+	mpurlResult := toTest.EquivalentsFor("application/x-mpegURL")
+	if !reflect.DeepEqual(mpurlResult, []string{"application/x-mpegURL", "video/m3u8"}) {
+		t.Errorf("EquivalentsFor returned %v when we expected \"application/x-mpegURL\", \"video/m3u8\"", mpurlResult)
+	}
+
+	otherResult := toTest.EquivalentsFor("media/rhubarb")
+	if !reflect.DeepEqual(otherResult, []string{"media/rhubarb"}) {
+		t.Errorf("EquivalentsFor returned %v when we expected \"media/rhubarb\"", otherResult)
+	}
+}

--- a/referenceapi/referenceapi.go
+++ b/referenceapi/referenceapi.go
@@ -9,20 +9,16 @@ import (
 	"log"
 )
 
+var ops common.DynamoDbOps
+var config common.Config
+var mimeEquivelentsCache common.MimeEquivalentsCache
+
 /*
 This script looks up a video in the interactivepublisher database and returns a plaintext url if it can be found
 */
 
 func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
-	config, configErr := common.NewConfig()
-	if configErr != nil {
-		log.Printf("ERROR Could not initialise config: %s", configErr)
-		return nil, configErr
-	}
-
-	ops := common.NewDynamoDbOps(config)
-
-	foundContent, errResponse := common.FindContent(ctx, &event.QueryStringParameters, ops, config)
+	foundContent, errResponse := common.FindContent(ctx, &event.QueryStringParameters, ops, config, mimeEquivelentsCache)
 	if errResponse != nil {
 		switch errResponse.StatusCode {
 		case 404:
@@ -44,5 +40,18 @@ func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*ev
 }
 
 func main() {
+	var err error
+	config, err = common.NewConfig()
+	if err != nil {
+		log.Printf("ERROR Could not initialise config: %s", err)
+		panic("could not initialise config")
+	}
+
+	ops = common.NewDynamoDbOps(config)
+	mimeEquivelentsCache, err = common.NewMimeEquivalentsCache(context.Background(), ops)
+	if err != nil {
+		log.Printf("ERROR Could not initialise mime equivalents: %s", err)
+		panic("could not initialise MIME equivalents")
+	}
 	lambda.Start(HandleEvent)
 }

--- a/video/video.go
+++ b/video/video.go
@@ -9,20 +9,16 @@ import (
 	"log"
 )
 
+var ops common.DynamoDbOps
+var config common.Config
+var mimeEquivelentsCache common.MimeEquivalentsCache
+
 /*
 This script looks up a video in the interactivepublisher database and returns a URL, if it can be found, in a location header
 */
 
 func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
-	config, configErr := common.NewConfig()
-	if configErr != nil {
-		log.Printf("ERROR Could not initialise config: %s", configErr)
-		return nil, configErr
-	}
-
-	ops := common.NewDynamoDbOps(config)
-
-	foundContent, errResponse := common.FindContent(ctx, &event.QueryStringParameters, ops, config)
+	foundContent, errResponse := common.FindContent(ctx, &event.QueryStringParameters, ops, config, mimeEquivelentsCache)
 	if errResponse != nil {
 		switch errResponse.StatusCode {
 		case 404:
@@ -44,5 +40,19 @@ func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*ev
 }
 
 func main() {
+	var err error
+	config, err = common.NewConfig()
+	if err != nil {
+		log.Printf("ERROR Could not initialise config: %s", err)
+		panic("could not initialise config")
+	}
+
+	ops = common.NewDynamoDbOps(config)
+	mimeEquivelentsCache, err = common.NewMimeEquivalentsCache(context.Background(), ops)
+	if err != nil {
+		log.Printf("ERROR Could not initialise mime equivalents: %s", err)
+		panic("could not initialise MIME equivalents")
+	}
+
 	lambda.Start(HandleEvent)
 }


### PR DESCRIPTION
## What does this change?

- Allows searching under alternate MIME types as listed in the "MIME equivalents" table (https://codemill.atlassian.net/browse/GP-712). 
- Fixes the issue of URL encodings not being handled properly (https://codemill.atlassian.net/browse/GP-711)
- Fixes ordering issues with encodings
- Fixes encodings tagged as `mobile` not showing up if `needs_mobile` is false

## How to test

- Find a video encoding listed as "video/m3u8"
- Search for it using `format=video/m3u8`
- Search for it using `format=video%2Fm3u8`
- Search for it using `format=application/x-mpegURL`

## How can we measure success?
Improved automated testing results
