### PR TITLE
Fix / Normalise HTML in test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.3.7
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.13.0
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-xmlfmt/xmlfmt v0.0.0-20211206191508-7fd73a941850 // indirect
 	github.com/google/uuid v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-xmlfmt/xmlfmt v0.0.0-20211206191508-7fd73a941850 h1:PSPmmucxGiFBtbQcttHTUc4LQ3P09AW+ldO2qspyKdY=
+github.com/go-xmlfmt/xmlfmt v0.0.0-20211206191508-7fd73a941850/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
## What does this change?
Uses a pretty-printer to normalise HTML response bodies (both the "actual" response and the "expected" response) before comparing them. Uses the Content-Type header to determine whether this should be applied or not.

## How to test

Re-run the test program. The only time an HTML body should fail the test is if there is a _substantive_ difference between the html responses.

The output log will show the normalised html for ease of comparison

## How can we measure success?
Easier to check the test outputs
