### PR TITLE
Fix multiple mappings

### DIFF
--- a/common/dynamo_ops.go
+++ b/common/dynamo_ops.go
@@ -269,8 +269,9 @@ func (ops *DynamoDbOpsImpl) QueryIdMappings(ctx context.Context, indexName strin
 	} else if len(response.Items) == 1 {
 		return NewIdMappingRecord(&response.Items[0])
 	} else {
-		log.Printf("WARNING Got %d idmapping records, expected only 1. Note that there is a hard limit of 20.", len(response.Items))
-		return NewIdMappingRecord(&response.Items[0])
+		log.Printf("WARNING Got %d idmapping records, expected only 1. Note that there is a hard limit of 20. Using the most recent.", len(response.Items))
+		mostRecent := len(response.Items) - 1 //the indexing setup in DynamoDB returns the oldest first (sort key is lastupdate)
+		return NewIdMappingRecord(&response.Items[mostRecent])
 	}
 }
 

--- a/common/find_content.go
+++ b/common/find_content.go
@@ -101,7 +101,6 @@ Returns:
 - a pointer to APIGatewayProxyResponse on error. This can be passed back directly to the runtime.
 */
 func FindContent(ctx context.Context, queryStringParams *map[string]string, ops DynamoDbOps, config Config, cache MimeEquivalentsCache) (*ContentResult, *events.APIGatewayProxyResponse) {
-	//FIXME: no memcache implementation yet, we'll see how necessary it actually is
 	idMapping, errResponse := getIDMapping(ctx, queryStringParams, ops, config)
 	if errResponse != nil {
 		return nil, errResponse


### PR DESCRIPTION
## What does this change?

if there is more than one content-id for the given octid / filebase then use the most recent content-id

## How to test

`octopusid=11951952&format=video/mp4` should return `https://cdn.theguardian.tv/mainwebsite/2016/12/26/161226GeorgeMichaelObit3_h264_publish.mp4`

