### PR TITLE
Return Nothing in the Body on 404 from Video Endpoint

### DIFF
--- a/video/video.go
+++ b/video/video.go
@@ -22,7 +22,7 @@ func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*ev
 	if errResponse != nil {
 		switch errResponse.StatusCode {
 		case 404:
-			return common.MakeResponseRaw(404, aws.String("No content found.\n"), "text/plain"), nil
+			return common.MakeResponseRaw(404, aws.String(""), "text/plain"), nil
 		default:
 			return errResponse, nil
 		}


### PR DESCRIPTION
## What does this change?

Makes the video endpoint return nothing on 404 to mirror likely broken old PHP output.

## How to test

Run 'make test'.