### PR TITLE
Minor improvements

### DIFF
--- a/common/dynamo_ops.go
+++ b/common/dynamo_ops.go
@@ -21,9 +21,9 @@ type DynamoDbOpsImpl struct {
 DynamoDbOps abstracts the actual DynamoDb operations so that we can mock them in testing
 */
 type DynamoDbOps interface {
-	QueryFCSIdForContentId(ctx context.Context, contentId int32) (*[]string, error)
+	QueryFCSIdForContentId(ctx context.Context, contentId int64) (*[]string, error)
 	QueryEncodingsForFCSId(ctx context.Context, fcsid string) ([]*Encoding, error)
-	QueryEncodingsForContentId(ctx context.Context, contentid int32, maybeSince *time.Time) ([]*Encoding, error)
+	QueryEncodingsForContentId(ctx context.Context, contentid int64, maybeSince *time.Time) ([]*Encoding, error)
 	QueryIdMappings(ctx context.Context, indexName string, keyFieldName string, searchTerm interface{}) (*IdMappingRecord, error)
 	GetAllMimeEquivalents(ctx context.Context) ([]*MimeEquivalent, error)
 }
@@ -54,7 +54,7 @@ select fcs_id from encodings left join mime_equivalents on (real_name=encodings.
 ```
 from line 273 of the original code
 */
-func (ops *DynamoDbOpsImpl) QueryFCSIdForContentId(ctx context.Context, contentId int32) (*[]string, error) {
+func (ops *DynamoDbOpsImpl) QueryFCSIdForContentId(ctx context.Context, contentId int64) (*[]string, error) {
 	expr, err := expression.NewBuilder().
 		WithKeyCondition(expression.Key("contentid").Equal(expression.Value(contentId))).
 		Build()
@@ -175,7 +175,7 @@ Returns:
 - a slice of pointers to matching Encoding records on success
 - an error on failure
 */
-func (ops *DynamoDbOpsImpl) QueryEncodingsForContentId(ctx context.Context, contentid int32, maybeSince *time.Time) ([]*Encoding, error) {
+func (ops *DynamoDbOpsImpl) QueryEncodingsForContentId(ctx context.Context, contentid int64, maybeSince *time.Time) ([]*Encoding, error) {
 	//equivalent SQL is select * from encodings left join mime_equivalents on (real_name=encodings.format) where contentid=$contentid order by vbitrate desc,lastupdate desc
 	keyTerms := expression.Key("contentid").Equal(expression.Value(contentid))
 	if maybeSince != nil {

--- a/common/dynamo_ops_mocks.go
+++ b/common/dynamo_ops_mocks.go
@@ -7,7 +7,7 @@ import (
 )
 
 type DynamoOpsMock struct {
-	LastContentId            int32
+	LastContentId            int64
 	FCSIdForContentIdResults *[]string
 	FCSIdForContentError     error
 
@@ -17,7 +17,7 @@ type DynamoOpsMock struct {
 
 	EncodingsForContentIdResults []*Encoding
 	EncodingsForContentIdError   error
-	ContentIdQueried             int32
+	ContentIdQueried             int64
 	ContentIdSince               *time.Time
 	IdMappingIndexQueried        string
 	IdMappingKeyFieldQueried     string
@@ -26,7 +26,7 @@ type DynamoOpsMock struct {
 	IdMappingError               error
 }
 
-func (ops *DynamoOpsMock) QueryFCSIdForContentId(ctx context.Context, contentId int32) (*[]string, error) {
+func (ops *DynamoOpsMock) QueryFCSIdForContentId(ctx context.Context, contentId int64) (*[]string, error) {
 	ops.LastContentId = contentId
 	if ops.FCSIdForContentError != nil {
 		return nil, ops.FCSIdForContentError
@@ -44,7 +44,7 @@ func (ops *DynamoOpsMock) QueryEncodingsForFCSId(ctx context.Context, fcsid stri
 	}
 }
 
-func (ops *DynamoOpsMock) QueryEncodingsForContentId(ctx context.Context, contentid int32, maybeSince *time.Time) ([]*Encoding, error) {
+func (ops *DynamoOpsMock) QueryEncodingsForContentId(ctx context.Context, contentid int64, maybeSince *time.Time) ([]*Encoding, error) {
 	ops.ContentIdQueried = contentid
 	copiedTime := *maybeSince
 	ops.ContentIdSince = &copiedTime

--- a/common/idmapping.go
+++ b/common/idmapping.go
@@ -9,7 +9,7 @@ import (
 )
 
 type IdMappingRecord struct {
-	contentId  int32
+	contentId  int64
 	filebase   string //base index
 	project    *string
 	lastupdate time.Time //range key for all indices
@@ -25,7 +25,7 @@ func NewIdMappingRecord(from *map[string]types.AttributeValue) (*IdMappingRecord
 			if err != nil {
 				return nil, err
 			}
-			result.contentId = int32(intValue)
+			result.contentId = intValue
 		}
 	}
 	if filebase, haveFileBase := (*from)["filebase"]; haveFileBase {

--- a/common/poster_image.go
+++ b/common/poster_image.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"log"
 	"regexp"
 )
 
@@ -12,11 +13,19 @@ Arguments:
 Returns:
 - URL of the poster image
 */
-func GeneratePosterImageURL(url string) (string, error) {
+func GeneratePosterImageURL(url string, pngPoster bool) (string, error) {
 	var re = regexp.MustCompile(`^(.*)\.[^\.]+$`)
 	matches := re.FindStringSubmatch(url)
 	if matches == nil {
 		return "", errors.New("the CDN URL was malformed (no file extension) ")
 	}
-	return matches[1] + "_poster.jpg", nil
+
+	log.Printf("GeneratePosterImageURL: pngPoster is %t", pngPoster)
+	xtn := ".jpg"
+	if pngPoster {
+		xtn = ".png"
+	}
+	log.Printf("poster path is %s", matches[1]+"_poster"+xtn)
+
+	return matches[1] + "_poster" + xtn, nil
 }

--- a/common/poster_image_test.go
+++ b/common/poster_image_test.go
@@ -8,8 +8,12 @@ import (
 Tests that the correct URL is returned for the poster image
 */
 func TestGeneratePosterImageURL(t *testing.T) {
-	result, _ := GeneratePosterImageURL("https://cdn.theguardian.tv/HLS/2018/06/06/091101BangladeshVillages.m3u8")
+	result, _ := GeneratePosterImageURL("https://cdn.theguardian.tv/HLS/2018/06/06/091101BangladeshVillages.m3u8", false)
 	if result != "https://cdn.theguardian.tv/HLS/2018/06/06/091101BangladeshVillages_poster.jpg" {
+		t.Errorf("Unexpected output: %s", result)
+	}
+	result, _ = GeneratePosterImageURL("https://cdn.theguardian.tv/HLS/2018/06/06/091101BangladeshVillages.m3u8", true)
+	if result != "https://cdn.theguardian.tv/HLS/2018/06/06/091101BangladeshVillages_poster.png" {
 		t.Errorf("Unexpected output: %s", result)
 	}
 }
@@ -18,7 +22,7 @@ func TestGeneratePosterImageURL(t *testing.T) {
 Tests an error is returned if the URL can not be parsed
 */
 func TestGeneratePosterImageURLError(t *testing.T) {
-	_, err := GeneratePosterImageURL("test")
+	_, err := GeneratePosterImageURL("test", false)
 	if err == nil {
 		t.Error("GeneratePosterImageURL returned no error for an invalid URL")
 	}

--- a/mediatag/mediatag.go
+++ b/mediatag/mediatag.go
@@ -90,8 +90,12 @@ func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*ev
 		extraArguments = extraArguments + " controls"
 	}
 	if _, hasAutoPlay := (event.QueryStringParameters)["autoplay"]; hasAutoPlay {
-		extraArguments = extraArguments + " autoplay"
+		extraArguments = extraArguments + " autoplay muted"
 	}
+	if _, hasMuted := (event.QueryStringParameters)["nomuted"]; hasMuted {
+		extraArguments = strings.ReplaceAll(extraArguments, "muted", "")
+	}
+
 	if _, hasLoop := (event.QueryStringParameters)["loop"]; hasLoop {
 		extraArguments = extraArguments + " loop"
 	}


### PR DESCRIPTION
## What does this change?

Minor improvements:

- make the content id a 64-bit number instead of 32. This is to allow us to generate "super-high" randomised IDs that do not conflict with existing content
- if `autoplay` is specified, also add `muted` as most browsers now won't autoplay unless it is there
- add `nomuted` option to explicitly remove `muted`
- add `png` option to specify that png poster frame is present instead of jpeg

## How to test

- https://multimedia.guardianapis.com/interactivevideos/mediatag.php?file=hostomel_airport_landscape&format=video%2Fmp4&maxwidth=600&autoplay=true&png&nocontrols should actually autoplay, with muted sound (in a browser)
- https://multimedia.guardianapis.com/interactivevideos/mediatag.php?file=hostomel_airport_landscape&format=video%2Fmp4&maxwidth=600&nomuted&autoplay=true&png will not autoplay but will play with sound when you click it
- https://multimedia.guardianapis.com/interactivevideos/video.php?file=hostomel_airport_landscape&format=video%2Fmp4&maxwidth=600&png&poster should redirect you to a working poster image (omitting `&png` will lead to "access denied" page)

## How can we measure success?
- poster images working for "100 days of war"
- able to auto-play media again
