### PR TITLE
add a "playsinline" argument for the media tag

### DIFF
--- a/mediatag/mediatag.go
+++ b/mediatag/mediatag.go
@@ -100,6 +100,10 @@ func HandleEvent(ctx context.Context, event *events.APIGatewayProxyRequest) (*ev
 		extraArguments = extraArguments + " loop"
 	}
 
+	if _, isInline := (event.QueryStringParameters)["playsinline"]; isInline {
+		extraArguments = extraArguments + " playsinline"
+	}
+
 	hTMLToReturn, err := templateHTML(foundContent, extraArguments)
 
 	if err != nil {


### PR DESCRIPTION
## What does this change?

add a "playsinline" argument for the media tag as requested by Sean Clarke

## How to test

add "&playsinline" to the mediatag and view what comes back. Should have "playsinline" in the media tag

## How can we measure success?

@seanclarkeguardian is happy
